### PR TITLE
fix tooltips

### DIFF
--- a/src/Tooltips/index.tsx
+++ b/src/Tooltips/index.tsx
@@ -28,7 +28,6 @@ const Tooltips: React.FC<TooltipsProps> = ({ id, text = '', children }) => {
           tooltipRef.current.style.bottom = height + 25 + 'px'
           setPosition(false)
         } else {
-          tooltipRef.current.style.top = height + window.scrollY + 25 + 'px'
           setPosition(true)
         }
       }}


### PR DESCRIPTION
Remove top styling biar jadi dinamis. Karena kalo ada styling top yang fix, dia akan nyesuain sama layar awal. Jadi kalo di scroll tooltips bakal di tempat yang sama (ga ngikutin parentnya)