### PR TITLE
Fix/tabs

### DIFF
--- a/src/Tabs/Tab/Tab.style.tsx
+++ b/src/Tabs/Tab/Tab.style.tsx
@@ -1,7 +1,9 @@
 import styled from 'styled-components'
 import { StyledTabProps } from './interface'
 
-export const StyledTab = styled.button<StyledTabProps>`
+export const StyledTab = styled.button<
+  StyledTabProps & React.ComponentPropsWithoutRef<'button'>
+>`
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/Tabs/Tab/index.tsx
+++ b/src/Tabs/Tab/index.tsx
@@ -16,6 +16,7 @@ const Tab: React.FC<TabProps> = ({
 
   return (
     <StyledTab
+      type="button"
       selected={selectedIndex === index}
       onClick={() => {
         if (selectedIndex !== index && index !== undefined) {

--- a/src/Tabs/TabGroup/TabGroupContext/index.tsx
+++ b/src/Tabs/TabGroup/TabGroupContext/index.tsx
@@ -8,9 +8,10 @@ const TabGroupContext = createContext<TabGroupContextProps>(
 export const useTabGroupContext = () => useContext(TabGroupContext)
 
 export const TabGroupProvider: React.FC<TabGroupProviderProps> = ({
+  initialSelectedIndex = 0,
   children,
 }) => {
-  const [selectedIndex, setSelectedIndex] = useState(0)
+  const [selectedIndex, setSelectedIndex] = useState(initialSelectedIndex)
 
   const contextValue = {
     selectedIndex,

--- a/src/Tabs/TabGroup/TabGroupContext/interface.ts
+++ b/src/Tabs/TabGroup/TabGroupContext/interface.ts
@@ -6,5 +6,6 @@ export interface TabGroupContextProps {
 }
 
 export interface TabGroupProviderProps {
+  initialSelectedIndex?: number
   children: ReactNode
 }

--- a/src/Tabs/TabGroup/index.tsx
+++ b/src/Tabs/TabGroup/index.tsx
@@ -5,10 +5,10 @@ import { TabGroupProvider } from './TabGroupContext'
 
 const TabGroup: React.FC<
   TabGroupProps & React.ComponentPropsWithoutRef<'div'>
-> = ({ children, ...props }) => {
+> = ({ initialSelectedIndex, children, ...props }) => {
   return (
     <TabGroupDiv {...props}>
-      <TabGroupProvider>
+      <TabGroupProvider initialSelectedIndex={initialSelectedIndex}>
         {children?.map((value, idx) => {
           return cloneElement(value, {
             title: value.props.title,

--- a/src/Tabs/TabGroup/interface.ts
+++ b/src/Tabs/TabGroup/interface.ts
@@ -2,5 +2,6 @@ import { ReactElement } from 'react'
 import { TabProps } from '../Tab/interface'
 
 export interface TabGroupProps {
+  initialSelectedIndex?: number
   children?: ReactElement<TabProps>[]
 }


### PR DESCRIPTION
** CHANGES **
- Add initialSelectedIndex attribute to TabGroup.

** NOTES **
I plan to use the newly added attribute like this:
![image](https://github.com/COMPFEST/silicon/assets/70869295/a34ba78b-69f9-4842-8e1e-279a8c0203e7)

to fix this bug:
![image](https://github.com/COMPFEST/silicon/assets/70869295/40512be8-314f-4a52-83f9-9a4aca8eca4d)

There are also leftover changes to fix the tab button issue. Should I discard them beforehand? (example: i set the tab type to `button` to prevent clicking a tab from submitting the registration form)